### PR TITLE
Don't overwrite sitepack on every restart.

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -3,7 +3,7 @@
 # copy config
 [[ ! -e /config/WebGrab++.config.xml ]] && \
 	cp /defaults/WebGrab++.config.xml /config/
-[[ ! -e /config/ini/siteini.pack ]] && \
+[[ ! -e /config/siteini.pack ]] && \
 	cp -R /defaults/ini/siteini.pack /config/
 
 # add cron file for running webgrab+plus


### PR DESCRIPTION
The condition in `30-config` will never work, since the path is incorrect, therefore all the siteini files are overwritten on every start.
