### PR TITLE
rebase to bionic update webgrab to latest versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/ubuntu:xenial
+FROM lsiobase/ubuntu:bionic
 
 # set version label
 ARG BUILD_DATE
@@ -7,8 +7,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="saarg"
 
 # package versions
-ARG WEBGRAB_VER="2.0.0"
-ARG WGUPDATE_VER="2.1.7_beta"
+ARG WEBGRAB_VER="2.1.0"
+ARG WGUPDATE_VER="2.1.9_beta"
 
 # environment variables.
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -16,8 +16,11 @@ ENV HOME /config
 
 RUN \
  echo "**** add mono repository ****" && \
+ apt-get update && \
+ apt-get install -y \
+	gnupg && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
- echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list && \
+ echo "deb http://download.mono-project.com/repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/mono-official.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/ubuntu:arm64v8-xenial
+FROM lsiobase/ubuntu:arm64v8-bionic
 
 # set version label
 ARG BUILD_DATE
@@ -7,8 +7,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="saarg"
 
 # package versions
-ARG WEBGRAB_VER="2.0.0"
-ARG WGUPDATE_VER="2.1.7_beta"
+ARG WEBGRAB_VER="2.1.0"
+ARG WGUPDATE_VER="2.1.9_beta"
 
 # environment variables.
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -16,8 +16,11 @@ ENV HOME /config
 
 RUN \
  echo "**** add mono repository ****" && \
+ apt-get update && \
+ apt-get install -y \
+	gnupg && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
- echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list && \
+ echo "deb http://download.mono-project.com/repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/mono-official.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/ubuntu:arm32v7-xenial
+FROM lsiobase/ubuntu:arm32v7-bionic
 
 # set version label
 ARG BUILD_DATE
@@ -7,8 +7,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="saarg"
 
 # package versions
-ARG WEBGRAB_VER="2.0.0"
-ARG WGUPDATE_VER="2.1.7_beta"
+ARG WEBGRAB_VER="2.1.0"
+ARG WGUPDATE_VER="2.1.9_beta"
 
 # environment variables.
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -16,8 +16,11 @@ ENV HOME /config
 
 RUN \
  echo "**** add mono repository ****" && \
+ apt-get update && \
+ apt-get install -y \
+	gnupg && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
- echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list && \
+ echo "deb http://download.mono-project.com/repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/mono-official.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,12 +99,14 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is an os release set release type to none to indicate no external release
-    stage("Set ENV os"){
+    // If this is a custom command to determine version use that command
+    stage("Set tag custom bash"){
       steps{
         script{
-          env.EXT_RELEASE = env.PACKAGE_TAG
-          env.RELEASE_LINK = 'none'
+          env.EXT_RELEASE = sh(
+            script: ''' echo V2.1.0 ''',
+            returnStdout: true).trim()
+            env.RELEASE_LINK = 'custom_command'
         }
       }
     }
@@ -592,11 +594,11 @@ pipeline {
              "tagger": {"name": "LinuxServer Jenkins","email": "jenkins@linuxserver.io","date": "'${GITHUB_DATE}'"}}' '''
         echo "Pushing New release for Tag"
         sh '''#! /bin/bash
-              echo "Updating base packages to ${PACKAGE_TAG}" > releasebody.json
+              echo "Updating to ${EXT_RELEASE_CLEAN}" > releasebody.json
               echo '{"tag_name":"'${EXT_RELEASE_CLEAN}'-ls'${LS_TAG_NUMBER}'",\
                      "target_commitish": "master",\
                      "name": "'${EXT_RELEASE_CLEAN}'-ls'${LS_TAG_NUMBER}'",\
-                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n**OS Changes:**\\n\\n' > start
+                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n**Remote Changes:**\\n\\n' > start
               printf '","draft": false,"prerelease": false}' >> releasebody.json
               paste -d'\\0' start releasebody.json > releasebody.json.done
               curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/releases -d @releasebody.json.done'''

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **28.05.19:** - Update to v2.1.0 and beta v2.1.9, rebase to bionic.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **21.03.19:** - Update to beta 2.1.7.
 * **19.02.19:** - Add pipeline logic and multi arch.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,8 @@
 
 # jenkins variables
 project_name: docker-webgrabplus
-external_type: os
+external_type: na
+custom_version_command: 'echo V2.1.0'
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -60,6 +60,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.05.19:", desc: "Update to v2.1.0 and beta v2.1.9, rebase to bionic." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "21.03.19:", desc: "Update to beta 2.1.7." }
   - { date: "19.02.19:", desc: "Add pipeline logic and multi arch." }


### PR DESCRIPTION
As we do not have a method for getting the latest version I also hard coded the version tag. 

I tested this locally to the best of my ability because of the bionic rebase might need some further testing. 

All I can confirm is that it runs ok with blank setup: 

```
root@9bb384d34e7d:/# /bin/bash /defaults/update.sh

             WebGrab+Plus/w MDB & REX Postprocess -- version V2.1.9             

                                Jan van Straaten                                
                             Francis De Paemeleere                              

            thanks to Paul Weterings and all the contributing users             
--------------------------------------------------------------------------------

Job started at 28/05/2019 18:55:21
timezone=UTC+00:00 mapped with timezone_id "Atlantic/Canary"
found: /config/siteini.pack/Misc/dummy.ini -- Revision 02
input file /data/guide.xml not found   ... created a new one ... 


      i=index  .=same  c=change  g=gab  r=replace  n=new


Group (0) :
update requested for - 1 - out of - 1 - channels for 9 day(s)
(   1/1   ) DUMMY -- chan. (xmltv_id=Example) -- mode Incremental
innnnnnnnn

   Summary for update of       Example
     missing shows added       0
     changed shows updated     0
     new shows added           9
     unchanged shows inspected 0
     total after update        9



Job finished at 28/05/2019 18:55:22 done in 1s
```