### PR TITLE
Update to resolve missing netstandards.dll for v3.1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN \
 	libmono-system-data4.0-cil \
 	libmono-system-net-http-webrequest4.0-cil \
 	libmono-system-web4.0-cil \
+	mono-devel \
 	mono-runtime \
 	unzip && \
  echo "**** install webgrabplus ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -27,7 +27,8 @@ RUN \
 	cron \
 	libmono-system-data4.0-cil \
 	libmono-system-net-http-webrequest4.0-cil \
-	libmono-system-web4.0-cil \        
+	libmono-system-web4.0-cil \
+	mono-devel \        
 	mono-runtime \
 	unzip && \
  echo "**** install webgrabplus ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -28,6 +28,7 @@ RUN \
 	libmono-system-data4.0-cil \
 	libmono-system-net-http-webrequest4.0-cil \
 	libmono-system-web4.0-cil \
+	mono-devel \
 	mono-runtime \
 	unzip && \
  echo "**** install webgrabplus ****" && \

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **05.06.21:** - Added mono-devel dependency.
 * **04.06.21:** - Update to version 3.1.8 beta.
 * **22.03.21:** - Update to version 3.1.7 beta.
 * **07.03.21:** - Update to version 3.1.6 beta.

--- a/package_versions.txt
+++ b/package_versions.txt
@@ -191,6 +191,7 @@ login1:4.5-1ubuntu2
 lsb-base9.20170808ubuntu1
 mawk1.3.3-17ubuntu3
 mono-4.0-gac6.12.0.122-0xamarin1+ubuntu1804b1
+mono-devel6.12.0.122-0xamarin1+ubuntu1804b1
 mono-gac6.12.0.122-0xamarin1+ubuntu1804b1
 mono-llvm-support6.12.0.122-0xamarin1+ubuntu1804b1
 mono-llvm-tools6.0+mono20190708165219-0xamarin2+ubuntu1804b1

--- a/package_versions.txt
+++ b/package_versions.txt
@@ -191,7 +191,6 @@ login1:4.5-1ubuntu2
 lsb-base9.20170808ubuntu1
 mawk1.3.3-17ubuntu3
 mono-4.0-gac6.12.0.122-0xamarin1+ubuntu1804b1
-mono-devel6.12.0.122-0xamarin1+ubuntu1804b1
 mono-gac6.12.0.122-0xamarin1+ubuntu1804b1
 mono-llvm-support6.12.0.122-0xamarin1+ubuntu1804b1
 mono-llvm-tools6.0+mono20190708165219-0xamarin2+ubuntu1804b1

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -62,6 +62,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "05.06.21:", desc: "Added mono-devel dependency." } 
   - { date: "04.06.21:", desc: "Update to version 3.1.8 beta." } 
   - { date: "22.03.21:", desc: "Update to version 3.1.7 beta." } 
   - { date: "07.03.21:", desc: "Update to version 3.1.6 beta." } 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-webgrabplus/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Added mono-devel (hopefully in the right format) to resolve the missing netstandards.dll

## Benefits of this PR and context:
fixes #42 
ensures that the v3.1.8 can be used

## How Has This Been Tested?
updated the docker with mono-devel and that resolved the error (also tried other packages but they did not)
I have NOT tested this in the build process, as I am unsure how I would do that. so hopefully the jenkins build will fail if I have done something incorrect

## Source / References:
#42
