### PR TITLE
Bump framework version to 7.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN \
   curl -o /tmp/dotnet-install.sh -L \
     https://dot.net/v1/dotnet-install.sh && \
   chmod +x /tmp/dotnet-install.sh && \
-  /tmp/dotnet-install.sh -c 6.0 --install-dir /app/dotnet --runtime dotnet && \
+  /tmp/dotnet-install.sh -c 7.0 --install-dir /app/dotnet --runtime dotnet && \
   echo "**** install webgrabplus ****" && \
   if [ -z "$WEBGRAB_VER" ]; then \
     WEBGRAB_VER=$(curl -fsL http://webgrabplus.com/download/sw | grep -m1 /download/sw/v | sed 's|.*/download/sw/v\(.*\)">V.*|\1|'); \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -26,7 +26,7 @@ RUN \
   curl -o /tmp/dotnet-install.sh -L \
     https://dot.net/v1/dotnet-install.sh && \
   chmod +x /tmp/dotnet-install.sh && \
-  /tmp/dotnet-install.sh -c 6.0 --install-dir /app/dotnet --runtime dotnet && \
+  /tmp/dotnet-install.sh -c 7.0 --install-dir /app/dotnet --runtime dotnet && \
   echo "**** install webgrabplus ****" && \
   if [ -z "$WEBGRAB_VER" ]; then \
     WEBGRAB_VER=$(curl -fsL http://webgrabplus.com/download/sw | grep -m1 /download/sw/v | sed 's|.*/download/sw/v\(.*\)">V.*|\1|'); \


### PR DESCRIPTION
------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-webgrabplus/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
The latest builds cannot execute the `WebGrab+Plus.dll` as the  app is now a 7.0 binary:
```
/app/wg++/bin.net # /app/dotnet/dotnet "WebGrab+Plus.dll" "/config"
You must install or update .NET to run this application.

App: /app/wg++/bin.net/WebGrab+Plus.dll
Architecture: arm64
Framework: 'Microsoft.NETCore.App', version '7.0.0' (arm64)
.NET location: /app/dotnet/

The following frameworks were found:
  6.0.21 at [/app/dotnet/shared/Microsoft.NETCore.App]

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=7.0.0&arch=arm64&rid=alpine.3.17-arm64
```  

Bumping the framework version to `7.x` fixes the issue.

## Benefits of this PR and context:
The app can now run again

## How Has This Been Tested?
- `docker run -it linuxserver/webgrabplus sh`
- ` curl -o /tmp/dotnet-install.sh -L  https://dot.net/v1/dotnet-install.sh && chmod +x /tmp/dotnet-install.sh`
- `/tmp/dotnet-install.sh -c 7.0 --install-dir /app/dotnet --runtime dotnet`
- `cd /app/wg++/bin.net`
- ` /app/dotnet/dotnet "WebGrab+Plus.dll" "/config"`
